### PR TITLE
fix jackson-databind dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation 'org.apache.kafka:kafka-streams:7.3.0-ce'
 
     // included for the Serdes
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
     implementation 'org.springframework.kafka:spring-kafka:3.0.4'
 
     implementation 'net.datafaker:datafaker:1.8.1'


### PR DESCRIPTION
One of the other dependencies pulls in v2.13.3 of Jackson Core which then causes a problem serializing/deserializing doubles with this newer version of jackson-databind. 